### PR TITLE
ci: fetch full history for git-versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # git-versioning резолвит версию по тегам/истории; shallow-клон ломает describe.
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # git-versioning резолвит версию по тегам/истории; shallow-клон ломает describe.
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Проблема

Пост-мёрж сборка на `master` ([run](https://github.com/1c-syntax/intellij-language-1c-bsl/actions/runs/28698536873)) падает на шаге **Build plugin**:

```
java.lang.IllegalStateException: couldn't find matching tag in shallow git repository
    at me.qoomon.gitversioning.commons.GitUtil.describe(GitUtil.java:84)
```

`git-versioning` вычисляет версию через `git describe` (по тегам/истории). Правило для ветки `master` использует `${describe.tag.version}.${describe.distance}-SNAPSHOT`, а `actions/checkout@v4` по умолчанию делает shallow-клон (`fetch-depth: 1`) — `describe` не может найти тег и падает.

На ветке PR #25 это не проявлялось, потому что там срабатывало правило `branch(".+")` (`${ref.slug}-${commit.short}`), которое `describe` не вызывает.

## Изменения

- `fetch-depth: 0` в checkout обоих workflow — `build.yml` и `release.yml` (в релизном тем более важно: там `publishPlugin` с корректной версией/тегом).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEHLaBE3PCoXkWraXA32Zp)_