### PR TITLE
test: add tests for BSL LS download &amp; connection logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,14 @@ jobs:
             ./gradlew buildPlugin --stacktrace
           '
 
+      # Платформенные тесты (BasePlatformTestCase) поднимают headless-IDE — как и buildPlugin,
+      # гоним их под сессией D-Bus с разблокированным gnome-keyring.
       - name: Test
-        run: ./gradlew test --stacktrace
+        run: |
+          dbus-run-session -- bash -c '
+            gnome-keyring-daemon --components=secrets --daemonize --unlock <<< ""
+            ./gradlew test --stacktrace
+          '
 
       - name: Verify plugin
         run: ./gradlew verifyPlugin --stacktrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
             ./gradlew buildPlugin --stacktrace
           '
 
+      - name: Test
+        run: ./gradlew test --stacktrace
+
       - name: Verify plugin
         run: ./gradlew verifyPlugin --stacktrace
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,10 @@ dependencies {
 
     compileOnly("org.jspecify:jspecify:1.0.0")
 
+    // JUnit 4 не поставляется IntelliJ Platform Gradle Plugin автоматически; нужен и для наших
+    // тестов (org.junit), и для базовых классов платформы (junit.framework.TestCase).
+    testImplementation("junit:junit:4.13.2")
+
     intellijPlatform {
         // С 2025.3 (253) IDEA Community слита в единый дистрибутив — координата intellijIdea.
         intellijIdea("2025.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
@@ -46,11 +47,59 @@ repositories {
     }
 }
 
-dependencies {
-    // Загрузчик BSL Language Server (скачивание/распаковка релиза с GitHub)
-    implementation("io.github.1c-syntax:utils:0.8.0")
+// --- github-api multi-release JAR workaround -------------------------------------------------
+// github-api поставляется как многорелизный JAR (Multi-Release: true). Classloader плагинов
+// IntelliJ игнорирует META-INF/versions/** (JBR/IDEA-220300), из-за чего в рантайме грузится
+// Java 8-заглушка org.kohsuke.github.extras.HttpClientGitHubConnector, чьи методы бросают
+// UnsupportedOperationException, а нужного конструктора (HttpClient) в ней нет — скачивание
+// BSL LS падает с NoSuchMethodError. «Расплющиваем» jar: поднимаем классы из META-INF/versions/11
+// в корень, чтобы classloader видел реальную реализацию для Java 11+. Оригинальный github-api
+// исключаем из utils и подключаем расплющенный + его транзитивные зависимости отдельно.
+val githubApiSource by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
 
-    compileOnly("org.jspecify:jspecify:1.0.0")
+dependencies {
+    add(githubApiSource.name, "org.kohsuke:github-api:1.327")
+}
+
+val githubApiArtifact = githubApiSource.incoming.artifactView {
+    componentFilter { it is ModuleComponentIdentifier && it.module == "github-api" }
+}.files.elements.map { it.single().asFile }
+
+val githubApiTransitives = githubApiSource.incoming.artifactView {
+    componentFilter { it is ModuleComponentIdentifier && it.module != "github-api" }
+}.files
+
+val flattenGithubApiJar by tasks.registering(Jar::class) {
+    archiveFileName = "github-api-flattened.jar"
+    destinationDirectory = layout.buildDirectory.dir("flattened-libs")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    // 1) версия для Java 11 — поднимаем в корень, она должна перекрыть базовые заглушки
+    from(zipTree(githubApiArtifact)) {
+        include("META-INF/versions/11/**")
+        eachFile { path = path.removePrefix("META-INF/versions/11/") }
+        includeEmptyDirs = false
+    }
+    // 2) остальные классы и ресурсы, кроме версий и исходного манифеста
+    from(zipTree(githubApiArtifact)) {
+        exclude("META-INF/versions/**", "META-INF/MANIFEST.MF")
+    }
+}
+
+dependencies {
+    // Загрузчик BSL Language Server (скачивание/распаковка релиза с GitHub). github-api тащим
+    // не транзитивно, а расплющенным (см. блок выше про Multi-Release/IDEA-220300).
+    implementation("io.github.1c-syntax:utils:0.8.0") {
+        exclude(group = "org.kohsuke", module = "github-api")
+    }
+    implementation(files(flattenGithubApiJar))
+    implementation(githubApiTransitives)
+
+    // JSpecify-аннотации нужны и в main, и в тестах (в т.ч. платформенных), поэтому implementation,
+    // а не compileOnly: джар крошечный, аннотации с CLASS-retention.
+    implementation("org.jspecify:jspecify:1.0.0")
 
     // JUnit 4 не поставляется IntelliJ Platform Gradle Plugin автоматически; нужен и для наших
     // тестов (org.junit), и для базовых классов платформы (junit.framework.TestCase).

--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/BslErrorReportSubmitter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/BslErrorReportSubmitter.java
@@ -91,11 +91,11 @@ public class BslErrorReportSubmitter extends ErrorReportSubmitter {
       + "```\n" + truncate(throwableText, MAX_STACKTRACE_LENGTH) + "\n```\n";
   }
 
-  private static String truncate(String value, int maxLength) {
+  static String truncate(String value, int maxLength) {
     return value.length() <= maxLength ? value : value.substring(0, maxLength) + "\n… (truncated)";
   }
 
-  private static String encode(String value) {
+  static String encode(String value) {
     return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProvider.java
@@ -83,7 +83,7 @@ public class BslLanguageServerConnectionProvider extends ProcessStreamConnection
     super.start();
   }
 
-  private List<String> resolveCommands(LanguageServerSettingsState settings) throws IOException {
+  List<String> resolveCommands(LanguageServerSettingsState settings) throws IOException {
     var commands = new ArrayList<String>();
 
     if (Boolean.TRUE.equals(settings.externalJar)) {
@@ -109,7 +109,7 @@ public class BslLanguageServerConnectionProvider extends ProcessStreamConnection
       ? Path.of(PathManager.getSystemPath(), "bsl-language-server")
       : Path.of(settings.installDir);
 
-    var downloader = new BslLanguageServerDownloader(installDir, resolveToken());
+    var downloader = createDownloader(installDir, resolveToken());
 
     if (Boolean.TRUE.equals(settings.downloadServer)) {
       var channel = Boolean.TRUE.equals(settings.prerelease)
@@ -124,16 +124,31 @@ public class BslLanguageServerConnectionProvider extends ProcessStreamConnection
           + "Set the external jar path or enable downloading in the settings."));
   }
 
-  private String resolveConfigurationFile(LanguageServerSettingsState settings) {
-    var basePath = project.getBasePath();
-    if (basePath == null || settings.configurationFile.isBlank()) {
+  /**
+   * Точка расширения для тестов: создаёт загрузчик сервера. Переопределяется в тестах,
+   * чтобы подменить обращение к GitHub на заглушку.
+   */
+  BslLanguageServerDownloader createDownloader(Path installDir, @Nullable String token) {
+    return new BslLanguageServerDownloader(installDir, token);
+  }
+
+  private @Nullable String resolveConfigurationFile(LanguageServerSettingsState settings) {
+    return resolveConfigurationFile(project.getBasePath(), settings.configurationFile);
+  }
+
+  /**
+   * Возвращает абсолютный путь к файлу конфигурации сервера относительно корня проекта,
+   * либо {@code null}, если корень неизвестен, имя не задано или файл отсутствует.
+   */
+  static @Nullable String resolveConfigurationFile(@Nullable String basePath, String configurationFile) {
+    if (basePath == null || configurationFile.isBlank()) {
       return null;
     }
-    var configurationFile = Path.of(basePath, settings.configurationFile);
-    if (Files.exists(configurationFile)) {
-      return configurationFile.toString();
+    var path = Path.of(basePath, configurationFile);
+    if (Files.exists(path)) {
+      return path.toString();
     }
-    LOG.warn("Configured BSL Language Server config file not found: " + configurationFile);
+    LOG.warn("Configured BSL Language Server config file not found: " + path);
     return null;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProvider.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.server.CannotStartProcessException;
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -74,7 +75,7 @@ public class BslLanguageServerConnectionProvider extends ProcessStreamConnection
       setWorkingDirectory(basePath);
     }
 
-    var javaOptions = mergedJavaOptions(settings.javaOpts);
+    var javaOptions = mergedJavaOptions(System.getenv(JAVA_OPTIONS_ENV), settings.javaOpts);
     if (javaOptions != null) {
       setUserEnvironmentVariables(Map.of(JAVA_OPTIONS_ENV, javaOptions));
     }
@@ -145,12 +146,18 @@ public class BslLanguageServerConnectionProvider extends ProcessStreamConnection
     return envToken == null || envToken.isBlank() ? null : envToken;
   }
 
-  private static String mergedJavaOptions(String javaOpts) {
+  /**
+   * Объединяет уже заданное значение {@code _JAVA_OPTIONS} с пользовательскими опциями.
+   *
+   * @param existing текущее значение {@code _JAVA_OPTIONS} (обычно из окружения), может быть {@code null}
+   * @param javaOpts пользовательские опции из настроек
+   * @return итоговое значение или {@code null}, если пользовательские опции пусты
+   */
+  static @Nullable String mergedJavaOptions(@Nullable String existing, @Nullable String javaOpts) {
     var options = javaOpts == null ? "" : javaOpts.strip();
     if (options.isEmpty()) {
       return null;
     }
-    var existing = System.getenv(JAVA_OPTIONS_ENV);
     return existing == null || existing.isBlank() ? options : existing + " " + options;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProvider.java
@@ -153,7 +153,7 @@ public class BslLanguageServerConnectionProvider extends ProcessStreamConnection
   }
 
   private static String resolveToken() {
-    var token = LanguageServerSettingsState.getGithubToken();
+    var token = LanguageServerSettingsState.githubToken();
     if (token != null && !token.isBlank()) {
       return token;
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/settings/LanguageServerSettingsState.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/settings/LanguageServerSettingsState.java
@@ -92,13 +92,20 @@ public class LanguageServerSettingsState implements PersistentStateComponent<Lan
   /**
    * GitHub OAuth-токен для обхода лимитов API при скачивании (необязателен).
    * Хранится в {@link PasswordSafe}, а не в открытом виде в настройках.
+   *
+   * <p><b>Важно:</b> методы намеренно НЕ следуют JavaBean-именованию
+   * ({@code getGithubToken}/{@code setGithubToken}). Иначе {@link XmlSerializerUtil} принимает
+   * {@code githubToken} за сериализуемое свойство состояния и обращается к {@link PasswordSafe}
+   * прямо в {@link #loadState} — это медленная операция внутри non-cancelable read action, что
+   * запрещено платформой (issue #30), — а заодно рискует записать токен в {@code intellij-bsl.xml}
+   * открытым текстом. Не переименовывай их обратно в {@code get}/{@code set}.
    */
   @Nullable
-  public static String getGithubToken() {
+  public static String githubToken() {
     return PasswordSafe.getInstance().getPassword(githubTokenCredentialAttributes());
   }
 
-  public static void setGithubToken(@Nullable String token) {
+  public static void storeGithubToken(@Nullable String token) {
     PasswordSafe.getInstance().setPassword(githubTokenCredentialAttributes(), token);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/settings/LanguageServerSettingsState.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/settings/LanguageServerSettingsState.java
@@ -32,8 +32,11 @@ import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+// name должен быть уникальным в пределах приложения. Обобщённое "LanguageServerSettingsState"
+// уже занято lsp4ij (com.redhat.devtools.lsp4ij.settings.GlobalLanguageServerSettings) —
+// совпадение приводит к «Conflicting component name». Поэтому имя плагин-специфичное.
 @State(
-  name = "LanguageServerSettingsState",
+  name = "Language1CBSLSettings",
   storages = @Storage("intellij-bsl.xml")
 )
 public class LanguageServerSettingsState implements PersistentStateComponent<LanguageServerSettingsState> {

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/BslErrorReportSubmitterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/BslErrorReportSubmitterTest.java
@@ -1,0 +1,50 @@
+/*
+ * This file is a part of IntelliJ Language 1C (BSL) Plugin.
+ *
+ * Copyright © 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * IntelliJ Language 1C (BSL) Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * IntelliJ Language 1C (BSL) Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with IntelliJ Language 1C (BSL) Plugin.
+ */
+package com.github._1c_syntax.bsl.intellij;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BslErrorReportSubmitterTest {
+
+  @Test
+  public void truncateKeepsValueWithinLimit() {
+    assertEquals("short", BslErrorReportSubmitter.truncate("short", 10));
+    assertEquals("exact", BslErrorReportSubmitter.truncate("exact", 5));
+  }
+
+  @Test
+  public void truncateCutsValueAboveLimit() {
+    var result = BslErrorReportSubmitter.truncate("0123456789", 4);
+    assertTrue(result.startsWith("0123"));
+    assertTrue(result.contains("truncated"));
+    assertFalse(result.contains("456789"));
+  }
+
+  @Test
+  public void encodeEscapesSpacesAndNewlines() {
+    assertEquals("a+b%0Ac", BslErrorReportSubmitter.encode("a b\nc"));
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderPlatformTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderPlatformTest.java
@@ -1,0 +1,158 @@
+/*
+ * This file is a part of IntelliJ Language 1C (BSL) Plugin.
+ *
+ * Copyright © 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * IntelliJ Language 1C (BSL) Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * IntelliJ Language 1C (BSL) Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with IntelliJ Language 1C (BSL) Plugin.
+ */
+package com.github._1c_syntax.bsl.intellij.lsp;
+
+import com.github._1c_syntax.bsl.intellij.settings.LanguageServerSettingsState;
+import com.github._1c_syntax.utils.downloader.BslLanguageServerDownloader;
+import com.github._1c_syntax.utils.downloader.BslLanguageServerReleaseChannel;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Платформенные тесты сборки команды запуска BSL Language Server. Обращение к GitHub за
+ * скачиванием сервера подменяется заглушкой {@link StubDownloader}, поэтому тесты не ходят в сеть.
+ */
+public class BslLanguageServerConnectionProviderPlatformTest extends BasePlatformTestCase {
+
+  public void testExternalJarBuildsJavaJarCommand() throws IOException {
+    var settings = new LanguageServerSettingsState();
+    settings.externalJar = Boolean.TRUE;
+    settings.javaPath = "java";
+    settings.path = "server.jar";
+    settings.configurationFile = "";
+
+    var commands = newProvider(new StubDownloader(Path.of("/stub/bsl"), Optional.empty()))
+      .resolveCommands(settings);
+
+    assertEquals(3, commands.size());
+    assertEquals("java", commands.get(0));
+    assertEquals("-jar", commands.get(1));
+    assertEquals(Path.of("server.jar").toAbsolutePath().toString(), commands.get(2));
+  }
+
+  public void testExternalJarUsesConfiguredJavaPath() throws IOException {
+    var settings = new LanguageServerSettingsState();
+    settings.externalJar = Boolean.TRUE;
+    settings.javaPath = "/opt/jdk/bin/java";
+    settings.path = "server.jar";
+    settings.configurationFile = "";
+
+    var commands = newProvider(new StubDownloader(Path.of("/stub/bsl"), Optional.empty()))
+      .resolveCommands(settings);
+
+    assertEquals("/opt/jdk/bin/java", commands.get(0));
+  }
+
+  public void testDownloadedBinaryUsesDownloaderResultAndPrereleaseChannel() throws IOException {
+    var settings = new LanguageServerSettingsState();
+    settings.externalJar = Boolean.FALSE;
+    settings.downloadServer = Boolean.TRUE;
+    settings.prerelease = Boolean.TRUE;
+    settings.configurationFile = "";
+
+    var stub = new StubDownloader(Path.of("/stub/bsl-language-server"), Optional.empty());
+    var commands = newProvider(stub).resolveCommands(settings);
+
+    assertEquals(Path.of("/stub/bsl-language-server").toString(), commands.get(0));
+    assertEquals(BslLanguageServerReleaseChannel.PRERELEASE, stub.requestedChannel);
+  }
+
+  public void testStableChannelWhenPrereleaseDisabled() throws IOException {
+    var settings = new LanguageServerSettingsState();
+    settings.externalJar = Boolean.FALSE;
+    settings.downloadServer = Boolean.TRUE;
+    settings.prerelease = Boolean.FALSE;
+    settings.configurationFile = "";
+
+    var stub = new StubDownloader(Path.of("/stub/bsl"), Optional.empty());
+    newProvider(stub).resolveCommands(settings);
+
+    assertEquals(BslLanguageServerReleaseChannel.STABLE, stub.requestedChannel);
+  }
+
+  public void testInstalledBinaryUsedWhenDownloadDisabled() throws IOException {
+    var settings = new LanguageServerSettingsState();
+    settings.externalJar = Boolean.FALSE;
+    settings.downloadServer = Boolean.FALSE;
+    settings.configurationFile = "";
+
+    var installed = Path.of("/installed/bsl-language-server");
+    var commands = newProvider(new StubDownloader(Path.of("/unused"), Optional.of(installed)))
+      .resolveCommands(settings);
+
+    assertEquals(installed.toString(), commands.get(0));
+  }
+
+  public void testThrowsWhenDownloadDisabledAndNothingInstalled() {
+    var settings = new LanguageServerSettingsState();
+    settings.externalJar = Boolean.FALSE;
+    settings.downloadServer = Boolean.FALSE;
+    settings.configurationFile = "";
+
+    try {
+      newProvider(new StubDownloader(Path.of("/unused"), Optional.empty())).resolveCommands(settings);
+      fail("Expected IOException when nothing is installed and downloading is disabled");
+    } catch (IOException expected) {
+      // ожидаемо
+    }
+  }
+
+  private BslLanguageServerConnectionProvider newProvider(BslLanguageServerDownloader downloader) {
+    return new BslLanguageServerConnectionProvider(getProject()) {
+      @Override
+      BslLanguageServerDownloader createDownloader(Path installDir, String token) {
+        return downloader;
+      }
+    };
+  }
+
+  /**
+   * Заглушка загрузчика: не обращается к GitHub, возвращает заранее заданный бинарь и запоминает
+   * запрошенный канал релизов.
+   */
+  private static final class StubDownloader extends BslLanguageServerDownloader {
+
+    private final Path binary;
+    private final Optional<Path> installed;
+    private BslLanguageServerReleaseChannel requestedChannel;
+
+    StubDownloader(Path binary, Optional<Path> installed) {
+      super(Path.of("."), null);
+      this.binary = binary;
+      this.installed = installed;
+    }
+
+    @Override
+    public Path downloadIfNeeded(BslLanguageServerReleaseChannel channel) {
+      requestedChannel = channel;
+      return binary;
+    }
+
+    @Override
+    public Optional<Path> installedBinary() {
+      return installed;
+    }
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderPlatformTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderPlatformTest.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.intellij.settings.LanguageServerSettingsState;
 import com.github._1c_syntax.utils.downloader.BslLanguageServerDownloader;
 import com.github._1c_syntax.utils.downloader.BslLanguageServerReleaseChannel;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -122,7 +123,7 @@ public class BslLanguageServerConnectionProviderPlatformTest extends BasePlatfor
   private BslLanguageServerConnectionProvider newProvider(BslLanguageServerDownloader downloader) {
     return new BslLanguageServerConnectionProvider(getProject()) {
       @Override
-      BslLanguageServerDownloader createDownloader(Path installDir, String token) {
+      BslLanguageServerDownloader createDownloader(Path installDir, @Nullable String token) {
         return downloader;
       }
     };

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderTest.java
@@ -23,6 +23,10 @@ package com.github._1c_syntax.bsl.intellij.lsp;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -46,5 +50,37 @@ public class BslLanguageServerConnectionProviderTest {
   public void mergedJavaOptionsAppendsUserOptionsToExisting() {
     assertEquals("-Xss2m -Xmx4g",
       BslLanguageServerConnectionProvider.mergedJavaOptions("-Xss2m", "-Xmx4g"));
+  }
+
+  @Test
+  public void resolveConfigurationFileIsNullForBlankBaseOrName() {
+    assertNull(BslLanguageServerConnectionProvider.resolveConfigurationFile(null, ".bsl-language-server.json"));
+    assertNull(BslLanguageServerConnectionProvider.resolveConfigurationFile("/whatever", ""));
+    assertNull(BslLanguageServerConnectionProvider.resolveConfigurationFile("/whatever", "   "));
+  }
+
+  @Test
+  public void resolveConfigurationFileIsNullWhenFileMissing() throws IOException {
+    var dir = Files.createTempDirectory("bsl-cfg-missing");
+    try {
+      assertNull(BslLanguageServerConnectionProvider.resolveConfigurationFile(
+        dir.toString(), ".bsl-language-server.json"));
+    } finally {
+      Files.deleteIfExists(dir);
+    }
+  }
+
+  @Test
+  public void resolveConfigurationFileReturnsAbsolutePathWhenPresent() throws IOException {
+    var dir = Files.createTempDirectory("bsl-cfg-present");
+    var configFile = dir.resolve(".bsl-language-server.json");
+    Files.writeString(configFile, "{}");
+    try {
+      assertEquals(configFile.toString(), BslLanguageServerConnectionProvider.resolveConfigurationFile(
+        dir.toString(), ".bsl-language-server.json"));
+    } finally {
+      Files.deleteIfExists(configFile);
+      Files.deleteIfExists(dir);
+    }
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/BslLanguageServerConnectionProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * This file is a part of IntelliJ Language 1C (BSL) Plugin.
+ *
+ * Copyright © 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * IntelliJ Language 1C (BSL) Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * IntelliJ Language 1C (BSL) Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with IntelliJ Language 1C (BSL) Plugin.
+ */
+package com.github._1c_syntax.bsl.intellij.lsp;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class BslLanguageServerConnectionProviderTest {
+
+  @Test
+  public void mergedJavaOptionsIsNullWhenUserOptionsBlank() {
+    assertNull(BslLanguageServerConnectionProvider.mergedJavaOptions(null, null));
+    assertNull(BslLanguageServerConnectionProvider.mergedJavaOptions("-Xmx1g", ""));
+    assertNull(BslLanguageServerConnectionProvider.mergedJavaOptions("-Xmx1g", "   "));
+  }
+
+  @Test
+  public void mergedJavaOptionsUsesUserOptionsWhenNoExisting() {
+    assertEquals("-Xmx4g", BslLanguageServerConnectionProvider.mergedJavaOptions(null, "-Xmx4g"));
+    assertEquals("-Xmx4g", BslLanguageServerConnectionProvider.mergedJavaOptions("", "  -Xmx4g  "));
+    assertEquals("-Xmx4g", BslLanguageServerConnectionProvider.mergedJavaOptions("   ", "-Xmx4g"));
+  }
+
+  @Test
+  public void mergedJavaOptionsAppendsUserOptionsToExisting() {
+    assertEquals("-Xss2m -Xmx4g",
+      BslLanguageServerConnectionProvider.mergedJavaOptions("-Xss2m", "-Xmx4g"));
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/GithubApiFlattenTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/lsp/GithubApiFlattenTest.java
@@ -1,0 +1,54 @@
+/*
+ * This file is a part of IntelliJ Language 1C (BSL) Plugin.
+ *
+ * Copyright © 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * IntelliJ Language 1C (BSL) Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * IntelliJ Language 1C (BSL) Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with IntelliJ Language 1C (BSL) Plugin.
+ */
+package com.github._1c_syntax.bsl.intellij.lsp;
+
+import org.junit.Test;
+import org.kohsuke.github.extras.HttpClientGitHubConnector;
+
+import java.net.http.HttpClient;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Регрессионный тест на issue #29. {@code github-api} — многорелизный JAR: рабочая реализация
+ * {@code HttpClientGitHubConnector} лежит в {@code META-INF/versions/11}, а в корне — Java 8-
+ * заглушка без конструктора {@code (HttpClient)}. Classloader плагинов IntelliJ игнорирует
+ * {@code META-INF/versions/**} ([IDEA-220300]), поэтому грузилась заглушка и загрузчик BSL LS падал
+ * с {@code NoSuchMethodError}. Сборка «расплющивает» jar (поднимает классы из
+ * {@code META-INF/versions/11} в корень); тест проверяет, что рабочая реализация действительно
+ * доступна из корня — как через рефлексию, так и через фактическое создание коннектора.
+ */
+public class GithubApiFlattenTest {
+
+  @Test
+  public void httpClientConstructorIsAvailable() throws Exception {
+    // именно этого конструктора не хватало в issue #29 (грузилась Java 8-заглушка без него)
+    assertNotNull(HttpClientGitHubConnector.class.getConstructor(HttpClient.class));
+  }
+
+  @Test
+  public void httpClientConnectorIsConstructible() {
+    // ровно этот вызов падал с NoSuchMethodError в issue #29
+    // (BslLanguageServerDownloader.latestRelease → new HttpClientGitHubConnector(httpClient))
+    assertNotNull(new HttpClientGitHubConnector(HttpClient.newHttpClient()));
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/intellij/settings/LanguageServerSettingsStateTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/intellij/settings/LanguageServerSettingsStateTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is a part of IntelliJ Language 1C (BSL) Plugin.
+ *
+ * Copyright © 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * IntelliJ Language 1C (BSL) Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * IntelliJ Language 1C (BSL) Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with IntelliJ Language 1C (BSL) Plugin.
+ */
+package com.github._1c_syntax.bsl.intellij.settings;
+
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.util.JDOMUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.xmlb.XmlSerializer;
+import com.redhat.devtools.lsp4ij.settings.GlobalLanguageServerSettings;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Регрессионные тесты на issue #30. GitHub-токен хранится в {@code PasswordSafe} и не должен
+ * попадать в сериализуемое состояние: иначе {@code XmlSerializer} трогает {@code PasswordSafe}
+ * в {@code loadState} (медленная операция внутри non-cancelable read action — запрещена), а токен
+ * рискует утечь в {@code intellij-bsl.xml} открытым текстом.
+ */
+public class LanguageServerSettingsStateTest extends BasePlatformTestCase {
+
+  /**
+   * Аксессоры токена не должны следовать JavaBean-именованию — иначе {@code XmlSerializer}
+   * принимает {@code githubToken} за сериализуемое свойство состояния (корень issue #30).
+   */
+  public void testGithubTokenAccessorsAreNotJavaBeanProperties() {
+    List<String> methodNames = Arrays.stream(LanguageServerSettingsState.class.getDeclaredMethods())
+      .map(Method::getName)
+      .toList();
+
+    assertFalse("getGithubToken сделал бы githubToken сериализуемым свойством (issue #30)",
+      methodNames.contains("getGithubToken"));
+    assertFalse("setGithubToken сделал бы githubToken сериализуемым свойством (issue #30)",
+      methodNames.contains("setGithubToken"));
+    assertTrue(methodNames.contains("githubToken"));
+    assertTrue(methodNames.contains("storeGithubToken"));
+  }
+
+  /**
+   * Даже если токен сохранён в {@code PasswordSafe}, он не должен появляться в сериализованном
+   * состоянии компонента — ни как значение, ни как свойство {@code githubToken}.
+   */
+  public void testGithubTokenNeverLeaksIntoSerializedState() throws Exception {
+    var secret = "ghp_must_not_be_serialized";
+    LanguageServerSettingsState.storeGithubToken(secret);
+    try {
+      var element = XmlSerializer.serialize(new LanguageServerSettingsState());
+      var xml = element == null ? "" : JDOMUtil.write(element);
+      assertFalse("токен утёк в сериализованное состояние (issue #30): " + xml, xml.contains(secret));
+      assertFalse("свойство githubToken не должно сериализоваться (issue #30): " + xml,
+        xml.contains("githubToken"));
+    } finally {
+      LanguageServerSettingsState.storeGithubToken(null);
+    }
+  }
+
+  /**
+   * Имя {@code @State} должно отличаться от lsp4ij: совпадающее имя даёт
+   * «Conflicting component name» при инициализации сервисов (репорт А. Сосновый).
+   */
+  public void testStateNameDoesNotCollideWithLsp4ij() {
+    var ourName = LanguageServerSettingsState.class.getAnnotation(State.class).name();
+    var lsp4ijName = GlobalLanguageServerSettings.class.getAnnotation(State.class).name();
+    assertFalse(
+      "имя @State совпадает с lsp4ij → Conflicting component name",
+      ourName.equals(lsp4ijName));
+  }
+}


### PR DESCRIPTION
Closes #29
Closes #30

## Что

Первые тесты плагина + попутные исправления рантайм-падений загрузчика/настроек, всплывших при реальной эксплуатации (#29, #30 и конфликт имён компонента с lsp4ij).

## Фикс #29 — `NoSuchMethodError` в `HttpClientGitHubConnector`

`github-api` — многорелизный JAR (`Multi-Release: true`): рабочая реализация `org.kohsuke.github.extras.HttpClientGitHubConnector` (конструктор `(HttpClient)`) лежит в `META-INF/versions/11/`, а в корне — Java 8-заглушка без этого конструктора. Classloader плагинов IntelliJ **игнорирует `META-INF/versions/**`** ([IDEA-220300](https://youtrack.jetbrains.com/issue/IDEA-220300)), поэтому грузилась заглушка и скачивание падало с `NoSuchMethodError` (в issue — 2026.2 Beta / Java 25).

Решение в `build.gradle.kts`: `github-api` исключается из транзитивных зависимостей `utils` и подключается «расплющенным» — классы из `META-INF/versions/11` поднимаются в корень jar. Транзитивы (`jackson`, `commons-*`) добавляются отдельно.

## Фикс #30 — `Non-cancelable slow operations are prohibited inside read action`

`getGithubToken()/setGithubToken()` следовали JavaBean-именованию, поэтому `XmlSerializer` принимал `githubToken` за сериализуемое свойство и обращался к `PasswordSafe` прямо в `loadState()` (медленная операция в non-cancelable read action — запрещена платформой 2026.2+). Та же привязка приводила бы к записи токена в `intellij-bsl.xml` открытым текстом.

Аксессоры переименованы в `githubToken()` / `storeGithubToken()`. Токен остаётся только в `PasswordSafe`.

## Фикс — `Conflicting component name 'LanguageServerSettingsState'`

`@State(name = "LanguageServerSettingsState")` совпадал с именем компонента lsp4ij (`GlobalLanguageServerSettings` — тоже `@State(name = "LanguageServerSettingsState")`). Имена компонентов уникальны в пределах приложения, поэтому платформа падала при инициализации сервисов. Задано плагин-специфичное имя `Language1CBSLSettings` (файл хранилища не меняется).

## Тесты

**Юнит (чистая логика):**
- `resolveConfigurationFile` / `mergedJavaOptions`;
- `BslErrorReportSubmitter.truncate/encode`;
- `GithubApiFlattenTest` (#29) — конструктор `HttpClientGitHubConnector(HttpClient)` доступен и коннектор создаётся.

**Платформенные (`BasePlatformTestCase`):**
- `resolveCommands`: внешний jar, скачанный/установленный бинарь, выбор канала релизов, ошибка при отсутствии (загрузчик подменён `StubDownloader`, GitHub не дёргается);
- `LanguageServerSettingsStateTest` (#30 + конфликт): аксессоры токена не JavaBean-свойства, токен не утекает в сериализованное состояние, имя `@State` отличается от lsp4ij.

Все тесты прогнаны локально (временно откатив Gradle/плагин на кэшированные версии, без коммита откатов); каждый новый тест проверен на «падучесть» — снимаешь фикс, тест краснеет.

> ⚠️ В обычном dev-окружении (Gradle 9 + IDE SDK 2025.3) не запускается — валидируется в CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEHLaBE3PCoXkWraXA32Zp)_