### PR TITLE
fix(textmate): drop plugin-version lookup from bundle extraction

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/intellij/textmate/BslTextMateBundleProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/intellij/textmate/BslTextMateBundleProvider.java
@@ -21,10 +21,8 @@
  */
 package com.github._1c_syntax.bsl.intellij.textmate;
 
-import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.extensions.PluginId;
 import org.jetbrains.plugins.textmate.api.TextMateBundleProvider;
 
 import java.io.IOException;
@@ -40,15 +38,13 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  * файлов {@code .bsl}/{@code .os} без регистрации собственного {@code FileType}.
  *
  * <p>TextMate требует бандл в виде каталога на файловой системе, а ресурсы плагина лежат в jar,
- * поэтому бандл распаковывается в служебный каталог IDE при инициализации.
+ * поэтому бандл распаковывается в служебный каталог IDE при каждом вызове {@code getBundles()}.
  */
 public class BslTextMateBundleProvider implements TextMateBundleProvider {
 
   private static final Logger LOG = Logger.getInstance(BslTextMateBundleProvider.class);
 
   private static final String BUNDLE_NAME = "1C (BSL)";
-  private static final String PLUGIN_ID = "io.github.1c-syntax.language-1c-bsl";
-  private static final String DEV_VERSION = "dev";
   private static final String RESOURCE_ROOT = "/textmate/1c-bsl";
   private static final List<String> BUNDLE_FILES = List.of(
     "package.json",
@@ -69,18 +65,14 @@ public class BslTextMateBundleProvider implements TextMateBundleProvider {
   }
 
   private Path extractBundle() throws IOException {
-    // Каталог версионируется версией плагина: при обновлении плагина создаётся новый каталог,
-    // а уже распакованные файлы текущей версии повторно не копируются.
-    var version = pluginVersion();
-    // В dev-сборках (sandbox/runIde) версия недоступна и каталог всегда один и тот же,
-    // поэтому файлы перераспаковываются каждый раз, чтобы правки грамматики подхватывались.
-    var reuseCached = !DEV_VERSION.equals(version);
-    var targetDir = Path.of(PathManager.getSystemPath(), "textmate-bundles", "1c-bsl", version);
+    // Файлы каждый раз перезаписываются в один и тот же каталог: набор мелкий, а точка
+    // расширения бандлов динамическая (dynamic="true") — getBundles() вызывается заново при
+    // (пере)загрузке плагина, поэтому обновлённая грамматика подхватывается без версионирования
+    // каталога. Каталог живёт под systemPath, что удовлетворяет требованию SPI «lifetime of
+    // those bundles matches the lifetime of a plugin».
+    var targetDir = Path.of(PathManager.getSystemPath(), "textmate-bundles", "1c-bsl");
     for (var relativePath : BUNDLE_FILES) {
       var target = targetDir.resolve(relativePath);
-      if (reuseCached && Files.exists(target)) {
-        continue;
-      }
       Files.createDirectories(target.getParent());
       try (InputStream input = BslTextMateBundleProvider.class.getResourceAsStream(RESOURCE_ROOT + "/" + relativePath)) {
         if (input == null) {
@@ -90,13 +82,5 @@ public class BslTextMateBundleProvider implements TextMateBundleProvider {
       }
     }
     return targetDir;
-  }
-
-  private static String pluginVersion() {
-    var descriptor = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));
-    if (descriptor != null && descriptor.getVersion() != null) {
-      return descriptor.getVersion();
-    }
-    return DEV_VERSION;
   }
 }


### PR DESCRIPTION
## Проблема

Верификация плагина против IntelliJ IDEA 2026.2 EAP (`262.8665.81`) сообщает об использовании внутреннего API:

> **Internal method usage (1)** — `PluginManagerCore.getPlugin(PluginId)`

В 2026.2 этот метод помечен `@ApiStatus.Internal`. Его очевидная замена `PluginManager.getInstance().findEnabledPlugin(PluginId)` тоже стала внутренней, а публичного способа получить дескриптор по `PluginId` пока нет.

Единственное место использования — `BslTextMateBundleProvider`, где версия плагина служила лишь ключом каталога, в который распаковывается TextMate-бандл.

## Решение

Версия в рантайме тут не нужна:

- Точка расширения `com.intellij.textmate.bundleProvider` объявлена `dynamic="true"`, поэтому `getBundles()` вызывается заново при каждой (пере)загрузке плагина — обновлённая грамматика подхватывается без версионирования каталога.
- SPI требует лишь, чтобы каталог бандла жил столько же, сколько плагин («lifetime of those bundles matches the lifetime of a plugin»); каталог под `PathManager.getSystemPath()` этому удовлетворяет.

Поэтому бандл (4 небольших файла) просто перезаписывается в стабильный каталог `…/textmate-bundles/1c-bsl` на каждом вызове. Это убирает использование внутреннего API целиком, а вместе с ним — ветвление dev/prod, вспомогательный метод `pluginVersion()` и хардкод id плагина.

## Изменения

- `BslTextMateBundleProvider`: убраны `pluginVersion()`, обращение к `PluginManagerCore`/classloader, константа `DEV_VERSION` и логика `reuseCached`; распаковка идёт в фиксированный каталог с `REPLACE_EXISTING`.

## Проверка

Сборку и верификацию локально прогнать не удалось: требуется Gradle 9.6.1, дистрибутив которого недоступен в этой среде (egress-политика возвращает 403 на `services.gradle.org`), а установлен только 8.14.3. Правка изолированная и только удаляет код — финальная проверка остаётся за CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKZistKUjPjtfziPgWgBqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKZistKUjPjtfziPgWgBqZ)_